### PR TITLE
Add realtime Click Race game with Express and WebSockets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,29 @@
-# click-race-game
-A simple and fun game to race against others
+# Click Race Game
+
+A simple realtime click race game built with Express and WebSockets. Players set a name, wait for a race and click as fast as possible during a 10 second window. A new race starts every minute if at least one player is waiting, and a live leaderboard is shared by all participants.
+
+## Features
+
+- Realtime lobby showing attendees for the next race
+- Automatic race start every minute when players are waiting
+- Profanity-filtered nicknames
+- Scores stored in DynamoDB
+
+## Running
+
+```bash
+# install dependencies
+npm install
+
+# run the server (expects AWS credentials with DynamoDB access)
+PORT=3000 node server.js
+```
+
+Environment variables:
+
+- `AWS_REGION` – AWS region of DynamoDB (default `us-east-1`)
+- `DDB_TABLE_SCORES` – table for scores (`ClickRaceScores` by default)
+- `DDB_TABLE_EVENTS` – table for events (`ClickRaceEvents` by default)
+- `RACE_DURATION_SECONDS` – duration of the click phase (default 10)
+
+Open `http://localhost:3000` in multiple browsers to play.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "click-race",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "test": "echo 'No tests specified'"
+  },
+  "dependencies": {
+    "@aws-sdk/client-dynamodb": "^3.679.0",
+    "@aws-sdk/lib-dynamodb": "^3.679.0",
+    "bad-words": "^3.0.4",
+    "express": "^4.19.2",
+    "helmet": "^7.1.0",
+    "leo-profanity": "^1.7.0",
+    "nanoid": "^5.0.7",
+    "ws": "^8.18.0",
+    "xss": "^1.0.15"
+  }
+}

--- a/profanity.js
+++ b/profanity.js
@@ -1,0 +1,32 @@
+import Filter from "bad-words";
+import leo from "leo-profanity";
+
+const badWords = new Filter();
+leo.loadDictionary();
+
+const L33T_MAP = { "0": "o", "1": "i", "3": "e", "4": "a", "5": "s", "7": "t", "$": "s", "@": "a" };
+
+function normalize(str) {
+  const lower = (str || "").toLowerCase().normalize("NFKD").replace(/\p{Diacritic}/gu, "");
+  return lower
+    .replace(/[013457@$]/g, c => L33T_MAP[c] || c)
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export function sanitizeName(input) {
+  let raw = (input || "")
+    .slice(0, 24)
+    .replace(/[\u0000-\u001f\u007f]/g, "")
+    .trim();
+  if (!raw) return null;
+
+  const norm = normalize(raw);
+  let clean = raw;
+
+  if (leo.check(norm)) clean = leo.clean(raw, "*");
+  if (badWords.isProfane(norm)) clean = badWords.clean(clean);
+
+  if (leo.check(normalize(clean)) || badWords.isProfane(normalize(clean))) return null;
+  return clean;
+}

--- a/public/client.js
+++ b/public/client.js
@@ -1,0 +1,88 @@
+const ws = new WebSocket(`ws://${location.host}`);
+
+const nameInput = document.getElementById("nameInput");
+const setNameBtn = document.getElementById("setNameBtn");
+const nameStatus = document.getElementById("nameStatus");
+const clickBtn = document.getElementById("clickBtn");
+const timerEl = document.getElementById("timer");
+const boardEl = document.getElementById("board");
+const lobbyDiv = document.getElementById("lobbyAttendees");
+const gameEl = document.getElementById("game");
+
+let running = false;
+let endsAt = 0;
+
+function escapeHtml(s) {
+  return (s || "").replace(/[&<>"']/g, c => ({"&":"&amp;","<":"&lt;",">":"&gt;","\"":"&quot;","'":"&#39;"}[c]));
+}
+
+function renderBoard(top) {
+  boardEl.innerHTML = top.map((p,i)=>
+    `<div class="flex justify-between px-4 py-2 bg-slate-900"><span>${i+1}. ${escapeHtml(p.name||"Player")}</span><span>${p.score}</span></div>`
+  ).join("");
+  if (top.length === 0) {
+    boardEl.innerHTML = '<div class="px-4 py-6 text-slate-500 text-center bg-slate-900">No players yet.</div>';
+  }
+}
+
+function updateTimer() {
+  if (!running) {
+    gameEl.classList.add("hidden");
+    return;
+  }
+  const ms = Math.max(0, endsAt - Date.now());
+  if (ms <= 0) {
+    running = false;
+    timerEl.textContent = "Race ended!";
+    gameEl.classList.add("hidden");
+    return;
+  }
+  timerEl.textContent = `Time left: ${(ms/1000).toFixed(1)}s`;
+  gameEl.classList.remove("hidden");
+  requestAnimationFrame(updateTimer);
+}
+
+ws.onmessage = e => {
+  const { type, data } = JSON.parse(e.data);
+  if (type === "name_ok") {
+    nameStatus.textContent = `Name set: ${data}`;
+    nameStatus.className = "text-sm text-emerald-400";
+  }
+  if (type === "error") {
+    nameStatus.textContent = data;
+    nameStatus.className = "text-sm text-rose-400";
+  }
+  if (type === "lobby_update") {
+    if (data.startsAt) {
+      const ms = Math.max(0, data.startsAt - Date.now());
+      timerEl.textContent = `Next race in ${(ms/1000).toFixed(0)}s`;
+    } else {
+      timerEl.textContent = "Waiting for players...";
+    }
+    lobbyDiv.innerHTML = data.attendees.map(p=>`<div class="px-3 py-1 bg-slate-800 rounded">${escapeHtml(p.name)}</div>`).join("");
+  }
+  if (type === "race_started") {
+    running = true;
+    endsAt = data.endsAt;
+    updateTimer();
+  }
+  if (type === "race_ended") {
+    running = false;
+    timerEl.textContent = "Race ended!";
+    gameEl.classList.add("hidden");
+  }
+  if (type === "leaderboard") {
+    running = data.running;
+    endsAt = Date.now() + data.endsInMs;
+    renderBoard(data.top);
+    if (running) updateTimer();
+  }
+};
+
+setNameBtn.onclick = () => {
+  ws.send(JSON.stringify({ type: "set_name", data: nameInput.value }));
+};
+
+clickBtn.onclick = () => {
+  if (running) ws.send(JSON.stringify({ type: "click" }));
+};

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Click Race</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="min-h-screen bg-slate-950 text-slate-100">
+  <div class="max-w-3xl mx-auto p-6">
+    <h1 class="text-3xl font-bold mb-2">⚡ Click Race</h1>
+    <p class="text-slate-400 mb-6">Set your name, wait for the race and click as fast as you can in 10 seconds.</p>
+
+    <div id="lobby" class="mb-6 space-y-3">
+      <div class="flex items-center gap-3">
+        <input id="nameInput" type="text" maxlength="24" placeholder="Your name"
+               class="w-64 px-3 py-2 rounded-lg bg-slate-800 border border-slate-700 focus:outline-none" />
+        <button id="setNameBtn" class="px-4 py-2 rounded-lg bg-emerald-600 hover:bg-emerald-500">
+          Save name
+        </button>
+      </div>
+      <div class="text-sm" id="nameStatus"></div>
+      <div id="timer" class="text-lg text-slate-300"></div>
+      <h3 class="text-lg font-semibold mt-4">Attendees for Next Race</h3>
+      <div id="lobbyAttendees" class="mt-2 space-y-1"></div>
+    </div>
+
+    <div id="game" class="hidden">
+      <button id="clickBtn"
+              class="w-full h-44 rounded-2xl bg-fuchsia-600 hover:bg-fuchsia-500 active:scale-95 transition text-2xl font-semibold">
+        CLICK!
+      </button>
+      <div class="mt-3 text-center text-slate-300">Spam the button while the timer runs.</div>
+    </div>
+
+    <div class="mt-8">
+      <h2 class="text-2xl font-semibold mb-3">Leaderboard</h2>
+      <div id="board" class="divide-y divide-slate-800 border border-slate-800 rounded-xl overflow-hidden"></div>
+    </div>
+  </div>
+
+  <script src="client.js"></script>
+</body>
+</html>

--- a/server.js
+++ b/server.js
@@ -1,0 +1,186 @@
+import express from "express";
+import helmet from "helmet";
+import { nanoid } from "nanoid";
+import xss from "xss";
+import { WebSocketServer } from "ws";
+
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import { DynamoDBDocumentClient, PutCommand, BatchWriteCommand, QueryCommand } from "@aws-sdk/lib-dynamodb";
+
+import { sanitizeName } from "./profanity.js";
+
+const {
+  PORT = 3000,
+  AWS_REGION = "us-east-1",
+  DDB_TABLE_SCORES = "ClickRaceScores",
+  DDB_TABLE_EVENTS = "ClickRaceEvents",
+  RACE_DURATION_SECONDS = 10
+} = process.env;
+
+const app = express();
+app.use(helmet({ contentSecurityPolicy: false }));
+app.use(express.json());
+app.use(express.static("public"));
+
+const server = app.listen(PORT, () => console.log(`Click Race running on :${PORT}`));
+const wss = new WebSocketServer({ server });
+
+const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({ region: AWS_REGION }));
+
+let raceId = null;
+let raceEndsAt = 0;
+let running = false;
+
+let players = new Map();
+let lobbyPlayers = new Map();
+let nextRaceStartAt = null;
+let raceTimer = null;
+
+function broadcast(type, data) {
+  const msg = JSON.stringify({ type, data });
+  [...players.keys(), ...lobbyPlayers.keys()].forEach(ws => {
+    if (ws.readyState === ws.OPEN) ws.send(msg);
+  });
+}
+
+function broadcastLobby() {
+  broadcast("lobby_update", {
+    startsAt: nextRaceStartAt,
+    attendees: [...lobbyPlayers.values()]
+  });
+}
+
+function broadcastLeaderboard() {
+  const top = [...players.values()].sort((a, b) => b.score - a.score).slice(0, 20);
+  broadcast("leaderboard", {
+    raceId,
+    running,
+    endsInMs: Math.max(0, raceEndsAt - Date.now()),
+    top
+  });
+}
+
+async function persistScore({ raceId, userId, name, score }) {
+  await ddb.send(new PutCommand({
+    TableName: DDB_TABLE_SCORES,
+    Item: { raceId, negScore: -score, userId, name, score, updatedAt: Date.now() }
+  }));
+}
+
+async function logEvent(type, payload) {
+  await ddb.send(new PutCommand({
+    TableName: DDB_TABLE_EVENTS,
+    Item: { pk: `race#${raceId || "none"}`, ts: Date.now(), type, payload }
+  }));
+}
+
+function scheduleRaceIfNeeded() {
+  if (!nextRaceStartAt && lobbyPlayers.size > 0) {
+    nextRaceStartAt = Date.now() + 60_000;
+    raceTimer = setInterval(checkRaceStart, 1000);
+  }
+}
+
+function checkRaceStart() {
+  if (!nextRaceStartAt) return;
+  const now = Date.now();
+  if (now >= nextRaceStartAt) {
+    if (lobbyPlayers.size > 0) {
+      startRace();
+    } else {
+      nextRaceStartAt = null;
+      clearInterval(raceTimer);
+      raceTimer = null;
+      broadcastLobby();
+    }
+  } else {
+    broadcastLobby();
+  }
+}
+
+function startRace() {
+  running = true;
+  raceId = nanoid(8);
+  raceEndsAt = Date.now() + RACE_DURATION_SECONDS * 1000;
+
+  players.clear();
+  lobbyPlayers.forEach((lp, ws) => {
+    players.set(ws, { ...lp, score: 0, lastClickTs: 0 });
+  });
+  lobbyPlayers.clear();
+
+  broadcast("race_started", { raceId, endsAt: raceEndsAt });
+  broadcastLeaderboard();
+  setTimeout(endRace, RACE_DURATION_SECONDS * 1000);
+}
+
+async function endRace() {
+  running = false;
+  broadcast("race_ended", { raceId });
+  broadcastLeaderboard();
+
+  const items = [...players.values()].map(p => ({
+    PutRequest: { Item: { raceId, negScore: -p.score, userId: p.userId, name: p.name, score: p.score, updatedAt: Date.now() } }
+  }));
+  for (let i = 0; i < items.length; i += 25) {
+    await ddb.send(new BatchWriteCommand({ RequestItems: { [DDB_TABLE_SCORES]: items.slice(i, i + 25) } }));
+  }
+  await logEvent("race_ended", { raceId });
+
+  players.clear();
+  raceId = null;
+  raceEndsAt = 0;
+  nextRaceStartAt = null;
+  clearInterval(raceTimer);
+  raceTimer = null;
+  broadcastLobby();
+}
+
+wss.on("connection", ws => {
+  const userId = `u_${nanoid(6)}`;
+  players.set(ws, { userId, name: null, score: 0, lastClickTs: 0 });
+
+  ws.on("message", msg => {
+    try {
+      const { type, data } = JSON.parse(msg);
+      if (type === "set_name") {
+        const clean = sanitizeName(String(data));
+        if (!clean) return ws.send(JSON.stringify({ type: "error", data: "Invalid name" }));
+        const safe = xss(clean);
+        const p = players.get(ws);
+        p.name = safe;
+        lobbyPlayers.set(ws, { userId: p.userId, name: p.name });
+        ws.send(JSON.stringify({ type: "name_ok", data: p.name }));
+        broadcastLobby();
+        scheduleRaceIfNeeded();
+      }
+      if (type === "click" && running) {
+        const p = players.get(ws);
+        if (!p) return;
+        const now = Date.now();
+        if (p.lastClickTs && now - p.lastClickTs < 20) return;
+        p.lastClickTs = now;
+        p.score += 1;
+        persistScore({ raceId, userId: p.userId, name: p.name, score: p.score }).catch(() => {});
+        broadcastLeaderboard();
+      }
+    } catch {}
+  });
+
+  ws.on("close", () => {
+    players.delete(ws);
+    lobbyPlayers.delete(ws);
+    broadcastLobby();
+    broadcastLeaderboard();
+  });
+});
+
+app.get("/api/race/:raceId/top", async (req, res) => {
+  const q = await ddb.send(new QueryCommand({
+    TableName: DDB_TABLE_SCORES,
+    KeyConditionExpression: "raceId = :r",
+    ExpressionAttributeValues: { ":r": req.params.raceId },
+    Limit: 20
+  }));
+  res.json({ raceId: req.params.raceId, top: q.Items || [] });
+});


### PR DESCRIPTION
## Summary
- build Express + WebSocket server that schedules a 10s click race every minute when players are waiting
- expose lobby and leaderboard updates, sanitize player names, and persist scores to DynamoDB
- add minimal frontend with Tailwind for joining, clicking and watching the leaderboard

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@aws-sdk%2fclient-dynamodb)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c7d22afeb083328d7aa36df7b44fde