### PR TITLE
Start races 30 seconds after first player joins

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Click Race Game
 
-A simple realtime click race game built with Express and WebSockets. Players set a name, wait for a race and click as fast as possible during a 10 second window. A new race starts every minute if at least one player is waiting, and a live leaderboard is shared by all participants.
+A simple realtime click race game built with Express and WebSockets. Players set a name, wait for a race and click as fast as possible during a 10 second window. A new race starts 30 seconds after the first player joins the lobby, and a live leaderboard is shared by all participants.
 
 ## Features
 
 - Realtime lobby showing attendees for the next race
-- Automatic race start every minute when players are waiting
+- Automatic race start 30 seconds after the first player joins
 - Profanity-filtered nicknames
 - Scores stored in DynamoDB
 

--- a/server.js
+++ b/server.js
@@ -76,7 +76,7 @@ async function logEvent(type, payload) {
 
 function scheduleRaceIfNeeded() {
   if (!nextRaceStartAt && lobbyPlayers.size > 0) {
-    nextRaceStartAt = Date.now() + 60_000;
+    nextRaceStartAt = Date.now() + 30_000;
     raceTimer = setInterval(checkRaceStart, 1000);
   }
 }


### PR DESCRIPTION
## Summary
- Start race automatically 30 seconds after the first player enters their name
- Refresh documentation to note new 30-second lobby wait time

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c7d3841dcc8332b883c577588f08c2