### PR TITLE
Add global leaderboard and race timestamp with QR link

### DIFF
--- a/public/client.js
+++ b/public/client.js
@@ -8,9 +8,19 @@ const timerEl = document.getElementById("timer");
 const boardEl = document.getElementById("board");
 const lobbyDiv = document.getElementById("lobbyAttendees");
 const gameEl = document.getElementById("game");
+const qrEl = document.getElementById("qrcode");
 
 let running = false;
 let endsAt = 0;
+
+function renderQr() {
+  if (!qrEl || !window.QRCode) return;
+  const canvas = document.createElement("canvas");
+  QRCode.toCanvas(canvas, window.location.href, { width: 128 }, () => {});
+  qrEl.innerHTML = "";
+  qrEl.appendChild(canvas);
+}
+renderQr();
 
 function escapeHtml(s) {
   return (s || "").replace(/[&<>"']/g, c => ({"&":"&amp;","<":"&lt;",">":"&gt;","\"":"&quot;","'":"&#39;"}[c]));

--- a/public/index.html
+++ b/public/index.html
@@ -34,11 +34,17 @@
     </div>
 
     <div class="mt-8">
-      <h2 class="text-2xl font-semibold mb-3">Leaderboard</h2>
+      <div class="flex items-center justify-between mb-3">
+        <h2 class="text-2xl font-semibold">Leaderboard</h2>
+        <a href="/leaderboard.html" class="text-sky-400 hover:underline">Global leaderboard</a>
+      </div>
       <div id="board" class="divide-y divide-slate-800 border border-slate-800 rounded-xl overflow-hidden"></div>
     </div>
+
+    <div id="qrcode" class="mt-8 flex justify-center"></div>
   </div>
 
+  <script src="https://cdn.jsdelivr.net/npm/qrcode@1.5.0/build/qrcode.min.js"></script>
   <script src="client.js"></script>
 </body>
 </html>

--- a/public/leaderboard.html
+++ b/public/leaderboard.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Click Race - Global Leaderboard</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="min-h-screen bg-slate-950 text-slate-100">
+  <div class="max-w-3xl mx-auto p-6">
+    <a href="/" class="text-sky-400 hover:underline">&larr; Back to game</a>
+    <h1 class="text-3xl font-bold mb-4">Global Leaderboard</h1>
+    <div id="board" class="divide-y divide-slate-800 border border-slate-800 rounded-xl overflow-hidden"></div>
+  </div>
+
+  <script src="leaderboard.js"></script>
+</body>
+</html>

--- a/public/leaderboard.js
+++ b/public/leaderboard.js
@@ -1,0 +1,22 @@
+const boardEl = document.getElementById("board");
+
+function escapeHtml(s) {
+  return (s || "").replace(/[&<>"']/g, c => ({"&":"&amp;","<":"&lt;",">":"&gt;","\"":"&quot;","'":"&#39;"}[c]));
+}
+
+function renderBoard(top) {
+  boardEl.innerHTML = top.map((p,i)=>
+    `<div class="flex justify-between px-4 py-2 bg-slate-900"><span>${i+1}. ${escapeHtml(p.name||"Player")}</span><span>${p.score} - ${new Date(p.finishedAt).toLocaleString()}</span></div>`
+  ).join("");
+  if (top.length === 0) {
+    boardEl.innerHTML = '<div class="px-4 py-6 text-slate-500 text-center bg-slate-900">No results yet.</div>';
+  }
+}
+
+async function load() {
+  const res = await fetch('/api/leaderboard');
+  const data = await res.json();
+  renderBoard(data.top || []);
+}
+
+load();


### PR DESCRIPTION
## Summary
- store final race results with finished time in DynamoDB
- add API and frontend page for global leaderboard across races
- render QR code linking to current app URL

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c7dc7825e48332bc8b50ea6632b04f