### PR TITLE
Add race identifiers and timestamps to global leaderboard

### DIFF
--- a/public/leaderboard.html
+++ b/public/leaderboard.html
@@ -10,7 +10,21 @@
   <div class="max-w-3xl mx-auto p-6">
     <a href="/" class="text-sky-400 hover:underline">&larr; Back to game</a>
     <h1 class="text-3xl font-bold mb-4">Global Leaderboard</h1>
-    <div id="board" class="divide-y divide-slate-800 border border-slate-800 rounded-xl overflow-hidden"></div>
+    <p class="mb-4 text-slate-300">Top results from every race. Columns show placement, player name, score, the race where it happened and when it finished.</p>
+    <div class="overflow-x-auto">
+      <table class="min-w-full divide-y divide-slate-800 border border-slate-800 rounded-xl overflow-hidden">
+        <thead class="bg-slate-900">
+          <tr>
+            <th class="px-4 py-2 text-left">Placement</th>
+            <th class="px-4 py-2 text-left">Player</th>
+            <th class="px-4 py-2 text-left">Result</th>
+            <th class="px-4 py-2 text-left">Race ID</th>
+            <th class="px-4 py-2 text-left">Time</th>
+          </tr>
+        </thead>
+        <tbody id="board" class="bg-slate-900"></tbody>
+      </table>
+    </div>
   </div>
 
   <script src="leaderboard.js"></script>

--- a/public/leaderboard.js
+++ b/public/leaderboard.js
@@ -5,11 +5,17 @@ function escapeHtml(s) {
 }
 
 function renderBoard(top) {
-  boardEl.innerHTML = top.map((p,i)=>
-    `<div class="flex justify-between px-4 py-2 bg-slate-900"><span>${i+1}. ${escapeHtml(p.name||"Player")}</span><span>${p.score} - ${new Date(p.finishedAt).toLocaleString()}</span></div>`
+  boardEl.innerHTML = top.map((p, i) =>
+    `<tr>
+      <td class="px-4 py-2">${i + 1}</td>
+      <td class="px-4 py-2">${escapeHtml(p.name || "Player")}</td>
+      <td class="px-4 py-2">${p.score}</td>
+      <td class="px-4 py-2">${p.raceId}</td>
+      <td class="px-4 py-2">${new Date(p.finishedAt).toLocaleString()}</td>
+    </tr>`
   ).join("");
   if (top.length === 0) {
-    boardEl.innerHTML = '<div class="px-4 py-6 text-slate-500 text-center bg-slate-900">No results yet.</div>';
+    boardEl.innerHTML = '<tr><td colspan="5" class="px-4 py-6 text-slate-500 text-center">No results yet.</td></tr>';
   }
 }
 


### PR DESCRIPTION
## Summary
- display race ID and completion time on the global leaderboard
- convert leaderboard to table with placement, player, result, race ID and time columns
- add descriptive text explaining what each column represents

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c7de69e94083329643313ad7e2608e