### PR TITLE
Add realtime progress bars and clicks-per-second metrics

### DIFF
--- a/public/client.js
+++ b/public/client.js
@@ -9,7 +9,11 @@ const boardEl = document.getElementById("board");
 const lobbyDiv = document.getElementById("lobbyAttendees");
 const gameEl = document.getElementById("game");
 const qrEl = document.getElementById("qrcode");
-const activeSessionsEl = document.getElementById("activeSessions");
+const showQrBtn = document.getElementById("showQrBtn");
+const qrModal = document.getElementById("qrModal");
+const activeSessionsCountEl = document.getElementById("activeSessionsCount");
+
+const RACE_DURATION_SECONDS = 10;
 
 let running = false;
 let endsAt = 0;
@@ -17,20 +21,38 @@ let endsAt = 0;
 function renderQr() {
   if (!qrEl || !window.QRCode) return;
   const canvas = document.createElement("canvas");
-  QRCode.toCanvas(canvas, window.location.href, { width: 128 }, () => {});
+  QRCode.toCanvas(canvas, window.location.href, { width: 256 }, () => {});
   qrEl.innerHTML = "";
   qrEl.appendChild(canvas);
 }
-renderQr();
+
+if (showQrBtn && qrModal) {
+  showQrBtn.onclick = () => {
+    qrModal.classList.remove("hidden");
+    renderQr();
+  };
+  qrModal.onclick = () => {
+    qrModal.classList.add("hidden");
+    qrEl.innerHTML = "";
+  };
+}
 
 function escapeHtml(s) {
   return (s || "").replace(/[&<>"']/g, c => ({"&":"&amp;","<":"&lt;",">":"&gt;","\"":"&quot;","'":"&#39;"}[c]));
 }
 
-function renderBoard(top) {
-  boardEl.innerHTML = top.map((p,i)=>
-    `<div class="flex justify-between px-4 py-2 bg-slate-900"><span>${i+1}. ${escapeHtml(p.name||"Player")}</span><span>${p.score}</span></div>`
-  ).join("");
+function renderBoard(top, duration) {
+  boardEl.innerHTML = top.map((p,i)=>{
+    const pct = Math.min(p.score, 100);
+    const elapsed = running ? Math.max(0, (duration * 1000 - (endsAt - Date.now()))/1000) : duration;
+    const cps = elapsed > 0 ? (p.score / elapsed).toFixed(2) : "0.00";
+    return `<div class="px-4 py-2 bg-slate-900">
+      <div class="flex justify-between text-sm sm:text-base"><span>${i+1}. ${escapeHtml(p.name||"Player")}</span><span>${p.score} (${cps}/s)</span></div>
+      <div class="w-full bg-slate-800 rounded h-2 mt-1">
+        <div class="bg-emerald-500 h-2 rounded" style="width:${pct}%"></div>
+      </div>
+    </div>`;
+  }).join("");
   if (top.length === 0) {
     boardEl.innerHTML = '<div class="px-4 py-6 text-slate-500 text-center bg-slate-900">No players yet.</div>';
   }
@@ -64,7 +86,7 @@ ws.onmessage = e => {
     nameStatus.className = "text-sm text-rose-400";
   }
   if (type === "active_sessions") {
-    activeSessionsEl.textContent = `Active sessions: ${data}`;
+    if (activeSessionsCountEl) activeSessionsCountEl.textContent = data;
   }
   if (type === "lobby_update") {
     if (data.startsAt) {
@@ -88,7 +110,7 @@ ws.onmessage = e => {
   if (type === "leaderboard") {
     running = data.running;
     endsAt = Date.now() + data.endsInMs;
-    renderBoard(data.top);
+    renderBoard(data.top, data.duration || RACE_DURATION_SECONDS);
     if (running) updateTimer();
   }
 };

--- a/public/index.html
+++ b/public/index.html
@@ -10,7 +10,13 @@
   <div class="max-w-3xl mx-auto p-6">
     <h1 class="text-3xl font-bold mb-2">⚡ Click Race</h1>
     <p class="text-slate-400">Set your name, wait for the race and click as fast as you can in 10 seconds.</p>
-    <p id="activeSessions" class="text-sm text-slate-400 mb-6">Active sessions: 0</p>
+    <div id="activeSessions" class="text-lg text-slate-200 mb-6 flex items-center">
+      <span class="relative flex h-4 w-4 mr-2">
+        <span class="animate-ping absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-75"></span>
+        <span class="relative inline-flex rounded-full h-4 w-4 bg-emerald-500"></span>
+      </span>
+      Online Users: <span id="activeSessionsCount" class="ml-1">0</span>
+    </div>
 
     <div id="lobby" class="mb-6 space-y-3">
       <div class="flex items-center gap-3">
@@ -42,7 +48,10 @@
       <div id="board" class="divide-y divide-slate-800 border border-slate-800 rounded-xl overflow-hidden"></div>
     </div>
 
-    <div id="qrcode" class="mt-8 flex justify-center"></div>
+    <button id="showQrBtn" class="hidden md:flex fixed right-0 top-1/2 -translate-y-1/2 px-4 py-2 bg-slate-700 hover:bg-slate-600 rounded-l-lg">Reveal QR code</button>
+    <div id="qrModal" class="hidden fixed inset-0 bg-black/60 flex items-center justify-center">
+      <div id="qrcode" class="bg-white p-4 rounded-lg"></div>
+    </div>
   </div>
 
   <script src="https://cdn.jsdelivr.net/npm/qrcode@1.5.0/build/qrcode.min.js"></script>

--- a/public/leaderboard.html
+++ b/public/leaderboard.html
@@ -18,6 +18,7 @@
             <th class="px-4 py-2 text-left">Placement</th>
             <th class="px-4 py-2 text-left">Player</th>
             <th class="px-4 py-2 text-left">Result</th>
+            <th class="px-4 py-2 text-left">Clicks/s</th>
             <th class="px-4 py-2 text-left">Race ID</th>
             <th class="px-4 py-2 text-left">Time</th>
           </tr>

--- a/public/leaderboard.js
+++ b/public/leaderboard.js
@@ -1,21 +1,24 @@
 const boardEl = document.getElementById("board");
+const RACE_DURATION_SECONDS = 10;
 
 function escapeHtml(s) {
   return (s || "").replace(/[&<>"']/g, c => ({"&":"&amp;","<":"&lt;",">":"&gt;","\"":"&quot;","'":"&#39;"}[c]));
 }
 
 function renderBoard(top) {
-  boardEl.innerHTML = top.map((p, i) =>
-    `<tr>
+  boardEl.innerHTML = top.map((p, i) => {
+    const cps = (p.score / RACE_DURATION_SECONDS).toFixed(2);
+    return `<tr>
       <td class="px-4 py-2">${i + 1}</td>
       <td class="px-4 py-2">${escapeHtml(p.name || "Player")}</td>
       <td class="px-4 py-2">${p.score}</td>
+      <td class="px-4 py-2">${cps}</td>
       <td class="px-4 py-2">${p.raceId}</td>
       <td class="px-4 py-2">${new Date(p.finishedAt).toLocaleString()}</td>
-    </tr>`
-  ).join("");
+    </tr>`;
+  }).join("");
   if (top.length === 0) {
-    boardEl.innerHTML = '<tr><td colspan="5" class="px-4 py-6 text-slate-500 text-center">No results yet.</td></tr>';
+    boardEl.innerHTML = '<tr><td colspan="6" class="px-4 py-6 text-slate-500 text-center">No results yet.</td></tr>';
   }
 }
 

--- a/server.js
+++ b/server.js
@@ -63,6 +63,7 @@ function broadcastLeaderboard() {
     raceId,
     running,
     endsInMs: Math.max(0, raceEndsAt - Date.now()),
+    duration: RACE_DURATION_SECONDS,
     top
   });
 }


### PR DESCRIPTION
## Summary
- Show online users with animated green status dot
- Add toggleable desktop QR code overlay
- Display real-time player progress bars with clicks-per-second stats
- Include clicks-per-second in global leaderboard

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c7fbd2acb88332a76442c20bbe9286