### PR TITLE
Enforce unique usernames and reset name form

### DIFF
--- a/public/client.js
+++ b/public/client.js
@@ -3,6 +3,7 @@ const ws = new WebSocket(`ws://${location.host}`);
 const nameInput = document.getElementById("nameInput");
 const setNameBtn = document.getElementById("setNameBtn");
 const nameStatus = document.getElementById("nameStatus");
+const nameForm = document.getElementById("nameForm");
 const clickBtn = document.getElementById("clickBtn");
 const timerEl = document.getElementById("timer");
 const boardEl = document.getElementById("board");
@@ -80,6 +81,7 @@ ws.onmessage = e => {
   if (type === "name_ok") {
     nameStatus.textContent = `Name set: ${data}`;
     nameStatus.className = "text-sm text-emerald-400";
+    if (nameForm) nameForm.classList.add("hidden");
   }
   if (type === "error") {
     nameStatus.textContent = data;
@@ -106,6 +108,12 @@ ws.onmessage = e => {
     running = false;
     timerEl.textContent = "Race ended!";
     gameEl.classList.add("hidden");
+    if (nameForm) {
+      nameForm.classList.remove("hidden");
+      nameInput.value = "";
+    }
+    nameStatus.textContent = "";
+    nameStatus.className = "text-sm";
   }
   if (type === "leaderboard") {
     running = data.running;

--- a/public/index.html
+++ b/public/index.html
@@ -19,11 +19,11 @@
     </div>
 
     <div id="lobby" class="mb-6 space-y-3">
-      <div class="flex items-center gap-3">
+      <div id="nameForm" class="flex items-center gap-3">
         <input id="nameInput" type="text" maxlength="24" placeholder="Your name"
                class="w-64 px-3 py-2 rounded-lg bg-slate-800 border border-slate-700 focus:outline-none" />
         <button id="setNameBtn" class="px-4 py-2 rounded-lg bg-emerald-600 hover:bg-emerald-500">
-          Save name
+          Play Now
         </button>
       </div>
       <div class="text-sm" id="nameStatus"></div>

--- a/server.js
+++ b/server.js
@@ -151,6 +151,11 @@ wss.on("connection", ws => {
         const clean = sanitizeName(String(data));
         if (!clean) return ws.send(JSON.stringify({ type: "error", data: "Invalid name" }));
         const safe = xss(clean);
+        const normalized = safe.toLowerCase();
+        const taken = [...players.values(), ...lobbyPlayers.values()].some(p =>
+          p.name && p.name.toLowerCase() === normalized
+        );
+        if (taken) return ws.send(JSON.stringify({ type: "error", data: "Name already taken" }));
         const p = players.get(ws);
         p.name = safe;
         lobbyPlayers.set(ws, { userId: p.userId, name: p.name });


### PR DESCRIPTION
## Summary
- prevent duplicate usernames across players during a race session
- hide the name form after joining and show it again when a race ends
- change lobby button text to "Play Now"

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c8009215048332afb9d8fd5b8bb653