### PR TITLE
Harden race flow and leaderboard handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ PORT=3000 node server.js
 Environment variables:
 
 - `AWS_REGION` – AWS region of DynamoDB (default `us-east-1`)
-- `DDB_TABLE_SCORES` – table for scores (`ClickRaceScores` by default)
-- `DDB_TABLE_EVENTS` – table for events (`ClickRaceEvents` by default)
+- `DDB_TABLE` – table used to store race results and leaderboard cache (`ClickRaceData` by default)
 - `RACE_DURATION_SECONDS` – duration of the click phase (default 10)
+- `ADMIN_TOKEN` – shared secret required by `/api/ban/:id` cockpit actions
 
 Open `http://localhost:3000` in multiple browsers to play.

--- a/src/express.mjs
+++ b/src/express.mjs
@@ -8,7 +8,13 @@ import { fileURLToPath } from "url";
 import { WebSocketServer, WebSocket } from "ws";
 
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
-import { DynamoDBDocumentClient, BatchWriteCommand, QueryCommand, ScanCommand } from "@aws-sdk/lib-dynamodb";
+import {
+  DynamoDBDocumentClient,
+  BatchWriteCommand,
+  GetCommand,
+  PutCommand,
+  QueryCommand
+} from "@aws-sdk/lib-dynamodb";
 
 import { sanitizeName } from "./profanity.js";
 
@@ -19,11 +25,16 @@ const {
   PORT = 80,
   AWS_REGION = "eu-central-1",
   DDB_TABLE = "ClickRaceData",
-  RACE_DURATION_SECONDS = 10
+  RACE_DURATION_SECONDS = 10,
+  ADMIN_TOKEN = ""
 } = process.env;
+
+const RACE_DURATION = Math.max(1, Number(RACE_DURATION_SECONDS) || 10);
 
 const app = express();
 app.use(cookieParser());
+
+app.disable("x-powered-by");
 
 app.use((req, res, next) => {
   if (req.cookies?.banned === "true" && !req.path.startsWith("/denied")) {
@@ -33,10 +44,12 @@ app.use((req, res, next) => {
 });
 
 app.use(helmet({ contentSecurityPolicy: false }));
-app.use(express.json());
+app.use(express.json({ limit: "8kb" }));
 
-let players = new Map();
-let lobbyPlayers = new Map();
+const clients = new Map();
+const activePlayers = new Map();
+const lobbyPlayers = new Map();
+const bannedIps = new Set();
 
 app.use(express.static(path.join(__dirname, "public")));
 
@@ -46,29 +59,52 @@ app.get("/api/getAttendees", (req, res) => {
 });
 
 function blockUser(userId) {
-  const target = [...players.entries(), ...lobbyPlayers.entries()]
-    .find(([ws, p]) => p.userId === userId);
-
-  if (target) {
-    const [ws] = target;
-    if (ws.readyState === WebSocket.OPEN) {
-      ws.send(JSON.stringify({ type: "banned" }));
+  for (const [ws, meta] of clients.entries()) {
+    if (meta.userId === userId) {
+      if (meta.ip) {
+        bannedIps.add(meta.ip);
+      }
+      activePlayers.delete(ws);
+      lobbyPlayers.delete(ws);
+      clients.delete(ws);
+      if (ws.readyState === WebSocket.OPEN) {
+        ws.send(JSON.stringify({ type: "banned" }));
+        ws.close(4403, "Banned");
+      }
+      broadcastLobby();
+      broadcastLeaderboard();
+      broadcastActiveSessions();
+      break;
     }
-    players.delete(ws);
-    lobbyPlayers.delete(ws);
-    broadcastLobby();
-    broadcastLeaderboard();
   }
 }
 
-app.post("/api/ban/:id", (req, res) => {
+function requireAdmin(req, res, next) {
+  if (!ADMIN_TOKEN) {
+    return res.status(503).json({ error: "Admin token not configured" });
+  }
+  const header = req.get("authorization") || "";
+  const token = header.startsWith("Bearer ") ? header.slice(7).trim() : "";
+  if (token !== ADMIN_TOKEN) {
+    return res.status(403).json({ error: "Forbidden" });
+  }
+  next();
+}
+
+app.post("/api/ban/:id", requireAdmin, (req, res) => {
   const { id } = req.params;
   blockUser(id);
   res.json({ ok: true });
 });
 
 app.get("/ban", (req, res) => {
-  res.cookie("banned", "true", { httpOnly: false, maxAge: 1000 * 60 * 60 * 24 });
+  const secure = req.secure || req.headers["x-forwarded-proto"] === "https";
+  res.cookie("banned", "true", {
+    httpOnly: true,
+    sameSite: "lax",
+    secure,
+    maxAge: 1000 * 60 * 60 * 24
+  });
   res.redirect("/denied");
 });
 
@@ -90,11 +126,49 @@ let running = false;
 let nextRaceStartAt = null;
 let raceTimer = null;
 
+function hasBannedCookie(cookieHeader = "") {
+  return /(?:^|;\s*)banned=true(?:;|$)/i.test(cookieHeader);
+}
+
 function broadcast(type, data) {
   const msg = JSON.stringify({ type, data });
-  [...players.keys(), ...lobbyPlayers.keys()].forEach(ws => {
+  wss.clients.forEach(ws => {
     if (ws.readyState === WebSocket.OPEN) ws.send(msg);
   });
+}
+
+function getLeaderboardData() {
+  const endsInMs = Math.max(0, raceEndsAt - Date.now());
+  const top = [...activePlayers.values()]
+    .map(p => ({ userId: p.userId, name: p.name, score: p.score }))
+    .sort((a, b) => {
+      if (b.score !== a.score) return b.score - a.score;
+      return a.userId.localeCompare(b.userId);
+    })
+    .slice(0, 20);
+  return {
+    raceId,
+    running,
+    endsInMs,
+    duration: RACE_DURATION,
+    top
+  };
+}
+
+function sendLobbySnapshot(ws) {
+  if (ws.readyState !== WebSocket.OPEN) return;
+  ws.send(JSON.stringify({
+    type: "lobby_update",
+    data: {
+      startsAt: nextRaceStartAt,
+      attendees: [...lobbyPlayers.values()]
+    }
+  }));
+}
+
+function sendLeaderboard(ws) {
+  if (ws.readyState !== WebSocket.OPEN) return;
+  ws.send(JSON.stringify({ type: "leaderboard", data: getLeaderboardData() }));
 }
 
 function broadcastLobby() {
@@ -105,18 +179,12 @@ function broadcastLobby() {
 }
 
 function broadcastLeaderboard() {
-  const top = [...players.values()].sort((a, b) => b.score - a.score).slice(0, 20);
-  broadcast("leaderboard", {
-    raceId,
-    running,
-    endsInMs: Math.max(0, raceEndsAt - Date.now()),
-    duration: RACE_DURATION_SECONDS,
-    top
-  });
+  broadcast("leaderboard", getLeaderboardData());
 }
 
 function scheduleRaceIfNeeded() {
-  if (!nextRaceStartAt && lobbyPlayers.size > 0) {
+  if (running || lobbyPlayers.size === 0) return;
+  if (!nextRaceStartAt) {
     nextRaceStartAt = Date.now() + 30_000;
     raceTimer = setInterval(checkRaceStart, 1000);
   }
@@ -142,17 +210,58 @@ function checkRaceStart() {
 function startRace() {
   running = true;
   raceId = nanoid(8);
-  raceEndsAt = Date.now() + RACE_DURATION_SECONDS * 1000;
+  raceEndsAt = Date.now() + RACE_DURATION * 1000;
 
-  players.clear();
+  activePlayers.clear();
   lobbyPlayers.forEach((lp, ws) => {
-    players.set(ws, { ...lp, score: 0, lastClickTs: 0 });
+    activePlayers.set(ws, { ...lp, score: 0, lastClickTs: 0 });
   });
   lobbyPlayers.clear();
 
+  nextRaceStartAt = null;
+  if (raceTimer) {
+    clearInterval(raceTimer);
+    raceTimer = null;
+  }
+
+  broadcastLobby();
   broadcast("race_started", { raceId, endsAt: raceEndsAt });
   broadcastLeaderboard();
-  setTimeout(endRace, RACE_DURATION_SECONDS * 1000);
+  setTimeout(endRace, RACE_DURATION * 1000);
+}
+
+async function updateGlobalLeaderboard(results, finishedAt, currentRaceId) {
+  if (!results.length) return;
+  const key = { raceId: "leaderboard", playerId: "global" };
+  const existing = await ddb.send(new GetCommand({ TableName: DDB_TABLE, Key: key }));
+  const existingTop = Array.isArray(existing.Item?.top) ? existing.Item.top : [];
+  const newEntries = results.map(p => ({
+    raceId: currentRaceId,
+    playerId: `player#${p.userId}`,
+    name: p.name,
+    score: p.score,
+    finishedAt
+  }));
+  const combined = [...existingTop, ...newEntries]
+    .filter(item => item && typeof item === "object");
+  combined.sort((a, b) => {
+    const diff = (b.score || 0) - (a.score || 0);
+    if (diff !== 0) return diff;
+    return (a.finishedAt || 0) - (b.finishedAt || 0);
+  });
+  const seen = new Set();
+  const limited = [];
+  for (const entry of combined) {
+    const dedupeKey = `${entry.raceId}#${entry.playerId}`;
+    if (seen.has(dedupeKey)) continue;
+    seen.add(dedupeKey);
+    limited.push(entry);
+    if (limited.length >= 100) break;
+  }
+  await ddb.send(new PutCommand({
+    TableName: DDB_TABLE,
+    Item: { ...key, top: limited }
+  }));
 }
 
 async function endRace() {
@@ -161,72 +270,138 @@ async function endRace() {
   broadcastLeaderboard();
 
   const finishedAt = Date.now();
-  const items = [...players.values()].map(p => ({
-    PutRequest: {
-      Item: {
-        raceId: `${raceId}`,
-        playerId: `player#${p.userId}`,
-        name: p.name,
-        score: p.score,
-        finishedAt,
+  const currentRaceId = raceId;
+  const results = [...activePlayers.values()];
+  if (results.length) {
+    try {
+      const items = results.map(p => ({
+        PutRequest: {
+          Item: {
+            raceId: `${currentRaceId}`,
+            playerId: `player#${p.userId}`,
+            name: p.name,
+            score: p.score,
+            finishedAt
+          }
+        }
+      }));
+      for (let i = 0; i < items.length; i += 25) {
+        await ddb.send(new BatchWriteCommand({
+          RequestItems: { [DDB_TABLE]: items.slice(i, i + 25) }
+        }));
       }
+      await updateGlobalLeaderboard(results, finishedAt, currentRaceId);
+    } catch (err) {
+      console.error("Failed to persist race results", err);
     }
-  }));
-  for (let i = 0; i < items.length; i += 25) {
-    await ddb.send(new BatchWriteCommand({ RequestItems: { [DDB_TABLE]: items.slice(i, i + 25) } }));
   }
 
-  players.clear();
+  activePlayers.clear();
   raceId = null;
   raceEndsAt = 0;
   nextRaceStartAt = null;
-  clearInterval(raceTimer);
-  raceTimer = null;
+  if (raceTimer) {
+    clearInterval(raceTimer);
+    raceTimer = null;
+  }
   broadcastLobby();
 }
 
-wss.on("connection", ws => {
-  const userId = `u_${nanoid(6)}`;
-  players.set(ws, { userId, name: null, score: 0, lastClickTs: 0 });
+function sendInitialState(ws) {
+  sendLobbySnapshot(ws);
+  sendLeaderboard(ws);
+  if (running) {
+    ws.send(JSON.stringify({ type: "race_started", data: { raceId, endsAt: raceEndsAt } }));
+  }
+}
 
+wss.on("connection", (ws, req) => {
+  const origin = req.headers.origin;
+  if (origin) {
+    try {
+      const { host } = new URL(origin);
+      if (host !== req.headers.host) {
+        ws.close(1008, "Forbidden origin");
+        return;
+      }
+    } catch {
+      ws.close(1008, "Forbidden origin");
+      return;
+    }
+  }
+
+  if (hasBannedCookie(req.headers.cookie)) {
+    ws.close(4403, "Banned");
+    return;
+  }
+
+  const ip = req.socket?.remoteAddress;
+  if (ip && bannedIps.has(ip)) {
+    ws.close(4403, "Banned");
+    return;
+  }
+
+  const userId = `u_${nanoid(6)}`;
+  clients.set(ws, { userId, name: null, ip });
+
+  sendInitialState(ws);
   broadcastActiveSessions();
 
   ws.on("message", msg => {
+    if (typeof msg !== "string" && !Buffer.isBuffer(msg)) return;
+    const raw = typeof msg === "string" ? msg : msg.toString("utf8");
+    if (raw.length > 1024) return;
+    let payload;
     try {
-      const { type, data } = JSON.parse(msg);
-      if (type === "set_name") {
-        const clean = sanitizeName(String(data));
-        if (!clean || !clean.trim()) {
-          return ws.send(JSON.stringify({ type: "error", data: "Invalid name" }));
-        }
-        const safe = xss(clean);
-        const normalized = safe.toLowerCase();
-        const taken = [...players.values(), ...lobbyPlayers.values()].some(
-          p => p.name && p.name.toLowerCase() === normalized
-        );
-        if (taken) return ws.send(JSON.stringify({ type: "error", data: "Name already taken" }));
-        const p = players.get(ws);
-        p.name = safe;
-        lobbyPlayers.set(ws, { userId: p.userId, name: p.name });
-        ws.send(JSON.stringify({ type: "name_ok", data: p.name }));
-        broadcastLobby();
-        scheduleRaceIfNeeded();
+      payload = JSON.parse(raw);
+    } catch {
+      return;
+    }
+    const { type, data } = payload || {};
+    const meta = clients.get(ws);
+    if (!meta) return;
+
+    if (type === "set_name") {
+      if (running) {
+        return ws.send(JSON.stringify({
+          type: "error",
+          data: "Rennen läuft aktuell. Bitte warte auf die nächste Runde."
+        }));
       }
-      if (type === "click" && running) {
-        const p = players.get(ws);
-        if (!p) return;
-        const now = Date.now();
-        if (p.lastClickTs && now - p.lastClickTs < 20) return;
-        p.lastClickTs = now;
-        p.score += 1;
-        broadcastLeaderboard();
+      const clean = sanitizeName(String(data ?? ""));
+      if (!clean || !clean.trim()) {
+        return ws.send(JSON.stringify({ type: "error", data: "Invalid name" }));
       }
-    } catch {}
+      const safe = xss(clean);
+      const normalized = safe.toLowerCase();
+      const taken = [...lobbyPlayers.values(), ...activePlayers.values()].some(
+        p => p.name && p.name.toLowerCase() === normalized
+      );
+      if (taken) {
+        return ws.send(JSON.stringify({ type: "error", data: "Name already taken" }));
+      }
+      meta.name = safe;
+      lobbyPlayers.set(ws, { userId: meta.userId, name: meta.name });
+      ws.send(JSON.stringify({ type: "name_ok", data: meta.name }));
+      broadcastLobby();
+      scheduleRaceIfNeeded();
+    }
+
+    if (type === "click" && running) {
+      const participant = activePlayers.get(ws);
+      if (!participant) return;
+      const now = Date.now();
+      if (participant.lastClickTs && now - participant.lastClickTs < 20) return;
+      participant.lastClickTs = now;
+      participant.score += 1;
+      broadcastLeaderboard();
+    }
   });
 
   ws.on("close", () => {
-    players.delete(ws);
     lobbyPlayers.delete(ws);
+    activePlayers.delete(ws);
+    clients.delete(ws);
     broadcastLobby();
     broadcastLeaderboard();
     broadcastActiveSessions();
@@ -234,18 +409,28 @@ wss.on("connection", ws => {
 });
 
 app.get("/api/race/:raceId/top", async (req, res) => {
-  const q = await ddb.send(new QueryCommand({
-    TableName: DDB_TABLE,
-    KeyConditionExpression: "raceId = :r AND begins_with(playerId, :p)",
-    ExpressionAttributeValues: { ":r": `${req.params.raceId}`, ":p": "player#" },
-    Limit: 20
-  }));
-  res.json({ raceId: req.params.raceId, top: q.Items || [] });
+  try {
+    const q = await ddb.send(new QueryCommand({
+      TableName: DDB_TABLE,
+      KeyConditionExpression: "raceId = :r AND begins_with(playerId, :p)",
+      ExpressionAttributeValues: { ":r": `${req.params.raceId}`, ":p": "player#" },
+      Limit: 20
+    }));
+    res.json({ raceId: req.params.raceId, top: q.Items || [] });
+  } catch (err) {
+    console.error("Failed to load race leaderboard", err);
+    res.status(500).json({ error: "Failed to load leaderboard" });
+  }
 });
 
 app.get("/api/leaderboard", async (req, res) => {
-  const scan = await ddb.send(new ScanCommand({ TableName: DDB_TABLE }));
-  const items = scan.Items?.filter(i => i.playerId.startsWith("player#")) || [];
-  const top = items.sort((a, b) => b.score - a.score).slice(0, 20);
-  res.json({ top });
+  try {
+    const key = { raceId: "leaderboard", playerId: "global" };
+    const result = await ddb.send(new GetCommand({ TableName: DDB_TABLE, Key: key }));
+    const top = Array.isArray(result.Item?.top) ? result.Item.top.slice(0, 20) : [];
+    res.json({ top });
+  } catch (err) {
+    console.error("Failed to load global leaderboard", err);
+    res.status(500).json({ error: "Failed to load leaderboard" });
+  }
 });

--- a/src/public/client.js
+++ b/src/public/client.js
@@ -17,6 +17,45 @@ const RACE_DURATION_SECONDS = 10;
 
 let running = false;
 let endsAt = 0;
+let joinLocked = false;
+let userHasName = false;
+
+function updateJoinFormVisibility() {
+  if (!nameForm) return;
+  if (userHasName) {
+    nameForm.classList.add("hidden");
+    nameInput.disabled = true;
+    setNameBtn.disabled = true;
+    return;
+  }
+  if (joinLocked) {
+    nameForm.classList.add("hidden");
+    nameInput.disabled = true;
+    setNameBtn.disabled = true;
+  } else {
+    nameForm.classList.remove("hidden");
+    nameInput.disabled = false;
+    setNameBtn.disabled = false;
+  }
+}
+
+function setJoinLock(lock) {
+  joinLocked = lock;
+  if (!userHasName) {
+    if (lock) {
+      nameStatus.textContent = "Rennen läuft gerade. Bitte warte auf die nächste Runde.";
+      nameStatus.className = "text-sm text-slate-300";
+      nameStatus.dataset.lockMessage = "true";
+    } else if (nameStatus.dataset.lockMessage === "true") {
+      nameStatus.textContent = "";
+      nameStatus.className = "text-sm";
+      delete nameStatus.dataset.lockMessage;
+    }
+  }
+  updateJoinFormVisibility();
+}
+
+updateJoinFormVisibility();
 
 function escapeHtml(s) {
   return (s || "").replace(/[&<>"']/g, c => ({
@@ -74,12 +113,15 @@ ws.onmessage = e => {
   }
 
   if (type === "name_ok") {
+    userHasName = true;
+    delete nameStatus.dataset.lockMessage;
     nameStatus.textContent = `Name set: ${data}`;
     nameStatus.className = "text-sm text-emerald-400";
-    if (nameForm) nameForm.classList.add("hidden");
+    updateJoinFormVisibility();
   }
 
   if (type === "error") {
+    delete nameStatus.dataset.lockMessage;
     nameStatus.textContent = data;
     nameStatus.className = "text-sm text-rose-400";
   }
@@ -101,12 +143,15 @@ ws.onmessage = e => {
   }
 
   if (type === "race_started") {
+    setJoinLock(true);
     running = true;
     endsAt = data.endsAt;
+    lobbyDiv.innerHTML = "";
     updateTimer();
   }
 
   if (type === "race_ended") {
+    setJoinLock(false);
     running = false;
     endsAt = 0;
 
@@ -127,10 +172,6 @@ ws.onmessage = e => {
       timerEl.insertAdjacentElement("afterend", playAgainBtn);
     }
 
-    // Allow user to join again
-    nameStatus.textContent = "";
-    nameStatus.className = "text-sm";
-
     // Clear board until next lobby/race update arrives
     renderBoard([], RACE_DURATION_SECONDS);
   }
@@ -138,12 +179,14 @@ ws.onmessage = e => {
   if (type === "leaderboard") {
     running = data.running;
     endsAt = Date.now() + data.endsInMs;
+    setJoinLock(data.running);
     renderBoard(data.top, data.duration || RACE_DURATION_SECONDS);
     if (running) updateTimer();
   }
 };
 
 setNameBtn.onclick = () => {
+  if (joinLocked || userHasName) return;
   ws.send(JSON.stringify({ type: "set_name", data: nameInput.value }));
 };
 

--- a/src/public/cockpit/index.html
+++ b/src/public/cockpit/index.html
@@ -14,31 +14,76 @@
 
     <script>
         const list = document.getElementById("attendees");
+        const TOKEN_KEY = "cockpitAdminToken";
+        let adminToken = sessionStorage.getItem(TOKEN_KEY) || "";
 
-        // Attendees live updaten
-        const ws = new WebSocket(`ws://${location.host}`);
+        function ensureToken() {
+            if (adminToken) return true;
+            const input = window.prompt("Bitte Admin-Token eingeben:");
+            if (!input) return false;
+            adminToken = input.trim();
+            if (adminToken) sessionStorage.setItem(TOKEN_KEY, adminToken);
+            return !!adminToken;
+        }
+
+        const ESCAPE_MAP = { "&": "&amp;", "<": "&lt;", ">": "&gt;", "\"": "&quot;", "'": "&#39;" };
+        function escapeHtml(value) {
+            return (value || "").replace(/[&<>"']/g, c => ESCAPE_MAP[c] || c);
+        }
+
+        ensureToken();
+
+        const protocol = location.protocol === "https:" ? "wss:" : "ws:";
+        const ws = new WebSocket(`${protocol}//${location.host}`);
         ws.onmessage = (ev) => {
             const msg = JSON.parse(ev.data);
             if (msg.type === "lobby_update") {
-                render(msg.data.attendees);
+                render(msg.data.attendees || []);
             }
         };
 
         function render(attendees) {
             list.innerHTML = attendees.map(p => `
-                <li class="flex justify-between items-center bg-slate-900 px-4 py-2 rounded">
-                    <span>${p.name}</span>
-                    <button onclick="blockPlayer('${p.userId}')"
-                        class="px-3 py-1 text-sm bg-rose-600 hover:bg-rose-500 rounded">
+                <li class="flex justify-between items-center bg-slate-900 px-4 py-2 rounded" data-user-id="${escapeHtml(p.userId)}">
+                    <span>${escapeHtml(p.name)}</span>
+                    <button class="px-3 py-1 text-sm bg-rose-600 hover:bg-rose-500 rounded" data-action="block">
                         Blockieren
                     </button>
                 </li>
             `).join("");
         }
 
-        function blockPlayer(id) {
-            fetch("/api/ban/" + id, { method: "POST" });
+        async function blockPlayer(id) {
+            if (!ensureToken()) {
+                alert("Admin-Token erforderlich.");
+                return;
+            }
+            try {
+                const res = await fetch(`/api/ban/${encodeURIComponent(id)}`, {
+                    method: "POST",
+                    headers: { Authorization: `Bearer ${adminToken}` },
+                    credentials: "same-origin"
+                });
+                if (res.status === 403 || res.status === 401 || res.status === 503) {
+                    sessionStorage.removeItem(TOKEN_KEY);
+                    adminToken = "";
+                    alert("Admin-Token ungültig. Bitte erneut eingeben.");
+                    ensureToken();
+                }
+            } catch (err) {
+                console.error("Block request failed", err);
+            }
         }
+
+        list.addEventListener("click", (event) => {
+            const target = event.target;
+            if (!(target instanceof HTMLButtonElement)) return;
+            if (target.dataset.action !== "block") return;
+            const parent = target.closest("[data-user-id]");
+            if (!parent) return;
+            const userId = parent.getAttribute("data-user-id");
+            if (userId) blockPlayer(userId);
+        });
     </script>
 </body>
 


### PR DESCRIPTION
## Summary
- Gate race participation on the server by tracking clients separately, blocking mid-race joins, enforcing admin tokens for bans, and rejecting untrusted WebSocket origins or banned IPs
- Broadcast precise lobby and race state transitions, persist race results, and cache a DynamoDB-backed global leaderboard so the API can serve the top players without scanning the entire table
- Hide the join form while races are running, clear attendees immediately at race start, and secure the cockpit controls with token prompts and sanitized rendering

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ca9dde58c08332956e90aba2d6229f