### PR TITLE
Hide live stats shortly before race start

### DIFF
--- a/src/public/client.js
+++ b/src/public/client.js
@@ -194,7 +194,15 @@ ws.onmessage = e => {
     running = data.running;
     endsAt = Date.now() + data.endsInMs;
     setJoinLock(data.running);
-    renderBoard(data.top, data.duration || RACE_DURATION_SECONDS);
+    if (boardEl) {
+      if (data.hidden) {
+        boardEl.innerHTML = "";
+        boardEl.classList.add("hidden");
+      } else {
+        boardEl.classList.remove("hidden");
+        renderBoard(data.top || [], data.duration || RACE_DURATION_SECONDS);
+      }
+    }
     updateGameVisibility();
     if (running) updateTimer();
   }


### PR DESCRIPTION
## Summary
- schedule a server-side timer that marks the leaderboard data as hidden five seconds before the next race begins and clears it when races start or are cancelled
- include the hidden flag in leaderboard messages so the client can blank the board until the race begins
- update the client to hide the live leaderboard while the hidden flag is set

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68caac4bcfe48332ab92698c760550ad